### PR TITLE
검색할 경우 페이지 화면 변화없는 문제 해결

### DIFF
--- a/src/main/java/site/metacoding/firstapp/domain/post/PostDao.java
+++ b/src/main/java/site/metacoding/firstapp/domain/post/PostDao.java
@@ -21,7 +21,7 @@ public interface PostDao {
                         @Param("keyword") String keyword);
 
         public List<PostListDto> findSearch(@Param("userId") Integer userId,
-                        @Param("keyword") String keyword);
+                        @Param("keyword") String keyword, @Param("startNum") int startNum);
 
         public List<Category> findAllcategory(Integer userId);
 

--- a/src/main/java/site/metacoding/firstapp/web/PostController.java
+++ b/src/main/java/site/metacoding/firstapp/web/PostController.java
@@ -59,7 +59,7 @@ public class PostController {
             // null이 아닐경우 //값에 안담김
 
             System.out.println("디버그 : userId : " + userId);
-            List<PostListDto> postList = postDao.findSearch(userId, keyword);
+            List<PostListDto> postList = postDao.findSearch(userId, keyword, startNum);
             PostPagingDto paging = postDao.paging(page, userId, keyword);// 페이지 호출
             paging.makeBlockInfo(keyword, userId);
             System.out.println("디버그 : keyword : " + keyword);

--- a/src/main/resources/mapper/post.xml
+++ b/src/main/resources/mapper/post.xml
@@ -51,15 +51,10 @@
         post WHERE user_id = #{userId} <if test="keyword != null"> and post_title like
         CONCAT('%',#{keyword},'%') </if> ) p </select>
 
-    <select id="findSearch" resultType="site.metacoding.firstapp.web.dto.post.PostListDto">
-        SELECT
-        p.*, c.* FROM category c JOIN post p 
-        ON p.category_id =c.category_id WHERE p.user_id  =#{userId} 
-        and p.post_title LIKE '%${keyword}%' 
-        OFFSET 0 ROWS FETCH NEXT 3 ROWS ONLY 
-    </select>
-
-
+    <select id="findSearch" resultType="site.metacoding.firstapp.web.dto.post.PostListDto"> SELECT
+        p.*, c.* FROM category c JOIN post p ON p.category_id =c.category_id WHERE p.user_id
+        =#{userId} and p.post_title LIKE '%${keyword}%' OFFSET #{startNum} ROWS FETCH NEXT 3 ROWS
+        ONLY </select>
 
 
 </mapper>


### PR DESCRIPTION
검색한 후 해당되는 페이지가 나오는데  검색은 작동은 하지만 처음 겁색된 페이지가 다음 페이지에서 똑같이 나오는 경우가 발생했다.

![image](https://user-images.githubusercontent.com/108706248/212457519-1cf1d502-524a-4bb7-a311-34f4ce7f12b1.png)
이 페이지만  1.2.3.페이지에 똑같이 나오는걸 볼수가 있었다.

해당 findSerch쿼리를  0 자리에 #{starNum}을 넣어서 페이지가 바뀌는것을 인식할수 있게 변경을 하였다.
변경 후에는 페이지가 서로 다르게 나온다.
